### PR TITLE
Player's marks are now stored in a separate document from the main ga…

### DIFF
--- a/Minesweeper.Backend/Minesweeper.GameServices/Extensions/IAsyncDocumentSessionExtensions.cs
+++ b/Minesweeper.Backend/Minesweeper.GameServices/Extensions/IAsyncDocumentSessionExtensions.cs
@@ -14,5 +14,20 @@ namespace Minesweeper.GameServices.Extensions
 
             return session.LoadAsync<Game>(id, cancellationToken);
         }
+
+        public static Task<PlayerMarks> LoadPlayerMarksAsync(this IAsyncDocumentSession session, string gameId, string playerId, CancellationToken cancellationToken)
+        {
+            var documentId = GetPlayerMarksDocumentId(session, gameId, playerId);
+
+            return session.LoadAsync<PlayerMarks>(documentId, cancellationToken);
+        }
+
+        public static string GetPlayerMarksDocumentId(this IAsyncDocumentSession session, string gameId, string playerId)
+        {
+            var collectionName = session.Advanced.DocumentStore.GetCollectionPrefixForDocument<PlayerMarks>(false);
+            var separator = session.Advanced.DocumentStore.Conventions.IdentityPartsSeparator;
+
+            return string.Join(separator, collectionName, gameId, playerId);
+        }
     }
 }

--- a/Minesweeper.Backend/Minesweeper.GameServices/Extensions/ServiceCollectionExtensions.cs
+++ b/Minesweeper.Backend/Minesweeper.GameServices/Extensions/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ namespace Minesweeper.GameServices.Extensions
                 .AddScoped<ILobbyService, LobbyService>()
                 .AddScoped<IRandomPlayerSelector, RandomPlayerSelector>()
                 .AddScoped<IGameGenerator, GameGenerator>()
+                .AddScoped<IPlayerMarksGenerator, PlayerMarksGenerator>()
                 .AddScoped<IMakeMoveCommandHandler, MakeMoveCommandHandler>()
                 .AddScoped<INewGameCommandHandler, NewGameCommandHandler>()
                 .AddScoped<IMarkFieldCommandHandler, MarkFieldCommandHandler>()

--- a/Minesweeper.Backend/Minesweeper.GameServices/GameModel/Game.cs
+++ b/Minesweeper.Backend/Minesweeper.GameServices/GameModel/Game.cs
@@ -29,9 +29,5 @@ namespace Minesweeper.GameServices.GameModel
         public FieldTypes[][] BaseTable { get; set; }
 
         public VisibleFieldType[][] VisibleTable { get; set; }
-
-        public MarkTypes[][] Player1Marks { get; set; }
-
-        public MarkTypes[][] Player2Marks { get; set; }
     }
 }

--- a/Minesweeper.Backend/Minesweeper.GameServices/GameModel/PlayerMarks.cs
+++ b/Minesweeper.Backend/Minesweeper.GameServices/GameModel/PlayerMarks.cs
@@ -1,0 +1,9 @@
+﻿namespace Minesweeper.GameServices.GameModel
+{
+    public class PlayerMarks
+    {
+        public string Id { get; set; }
+
+        public MarkTypes[][] Marks { get; set; }
+    }
+}

--- a/Minesweeper.Backend/Minesweeper.GameServices/GameService.cs
+++ b/Minesweeper.Backend/Minesweeper.GameServices/GameService.cs
@@ -24,19 +24,14 @@ namespace Minesweeper.GameServices
         {
             using (var session = _documentStore.OpenAsyncSession())
             {
-                var game = await session.LoadGameAsync(gameId, cancellationToken).ConfigureAwait(false);
+                var playerMarksDocument = await session.LoadPlayerMarksAsync(gameId, playerId, cancellationToken).ConfigureAwait(false);
 
-                var isPlayer1 = game.Player1.PlayerId == playerId;
-                var isPlayer2 = game.Player2.PlayerId == playerId;
-
-                if (!isPlayer1 && !isPlayer2)
+                if (playerMarksDocument == null)
                 {
                     throw new ActionNotAllowedException("You are not involved in that game.");
                 }
 
-                var playerMarks = isPlayer1 ? game.Player1Marks : game.Player2Marks;
-
-                return EnumArrayCloner.CloneAndMap(playerMarks, MarkTypeConverter.ToContract);
+                return EnumArrayCloner.CloneAndMap(playerMarksDocument.Marks, MarkTypeConverter.ToContract);
             }
         }
 

--- a/Minesweeper.Backend/Minesweeper.GameServices/Generators/GameGenerator.cs
+++ b/Minesweeper.Backend/Minesweeper.GameServices/Generators/GameGenerator.cs
@@ -19,21 +19,14 @@ namespace Minesweeper.GameServices.Generators
         public Game GenerateGame(int tableRows, int tableColumns, int mineCount)
         {
             var starterPlayer = _randomPlayerSelector.SelectRandomPlayer();
-
-            var player1Marks = new MarkTypes[tableRows][];
-            var player2Marks = new MarkTypes[tableRows][];
             var visibleTable = new VisibleFieldType[tableRows][];
 
             for (var row = 0; row < tableRows; ++row)
             {
-                player1Marks[row] = new MarkTypes[tableColumns];
-                player2Marks[row] = new MarkTypes[tableColumns];
                 visibleTable[row] = new VisibleFieldType[tableColumns];
 
                 for (var col = 0; col < tableColumns; ++col)
                 {
-                    player1Marks[row][col] = MarkTypes.None;
-                    player2Marks[row][col] = MarkTypes.None;
                     visibleTable[row][col] = VisibleFieldType.Unknown;
                 }
             }
@@ -42,8 +35,6 @@ namespace Minesweeper.GameServices.Generators
             {
                 BaseTable = GenerateBaseTable(tableRows, tableColumns, mineCount),
                 VisibleTable = visibleTable,
-                Player1Marks = player1Marks,
-                Player2Marks = player2Marks,
                 NextPlayer = starterPlayer,
                 Status = GameStatus.NotStarted,
                 Rows = tableRows,

--- a/Minesweeper.Backend/Minesweeper.GameServices/Generators/IPlayerMarksGenerator.cs
+++ b/Minesweeper.Backend/Minesweeper.GameServices/Generators/IPlayerMarksGenerator.cs
@@ -1,0 +1,9 @@
+﻿using Minesweeper.GameServices.GameModel;
+
+namespace Minesweeper.GameServices.Generators
+{
+    public interface IPlayerMarksGenerator
+    {
+        MarkTypes[][] GenerateDefaultPlayerMarksTable(int tableRows, int tableColumns);
+    }
+}

--- a/Minesweeper.Backend/Minesweeper.GameServices/Generators/PlayerMarksGenerator.cs
+++ b/Minesweeper.Backend/Minesweeper.GameServices/Generators/PlayerMarksGenerator.cs
@@ -1,0 +1,24 @@
+﻿using Minesweeper.GameServices.GameModel;
+
+namespace Minesweeper.GameServices.Generators
+{
+    public class PlayerMarksGenerator : IPlayerMarksGenerator
+    {
+        public MarkTypes[][] GenerateDefaultPlayerMarksTable(int tableRows, int tableColumns)
+        {
+            var marks = new MarkTypes[tableRows][];
+
+            for (var row = 0; row < tableRows; ++row)
+            {
+                marks[row] = new MarkTypes[tableColumns];
+
+                for (var col = 0; col < tableColumns; ++col)
+                {
+                    marks[row][col] = MarkTypes.None;
+                }
+            }
+
+            return marks;
+        }
+    }
+}


### PR DESCRIPTION
…me document.

This reduces possible concurrency issues, e.g. if a player performs marking during the other player's turn and also reduces DB traffic.